### PR TITLE
Login page nyt viimeistelty && napit paranneltu että saa kuvan myös o…

### DIFF
--- a/frontend/src/app/features/login-page/login-page.component.css
+++ b/frontend/src/app/features/login-page/login-page.component.css
@@ -1,14 +1,19 @@
 /* Kortti */
 .container-opaque {
+  position: relative;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   gap: 32px;
-  padding: 80px;
-  background: var(--color-background);
-  border: 1px solid #565656;
+  padding: 5rem;
   border-radius: 8px;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
-  height: auto;
+  box-sizing: border-box;
+
+  /* Gradienttireuna */
+  background: linear-gradient(var(--color-background), var(--color-background))
+      padding-box,
+    linear-gradient(180deg, #404040 0%, #6b6b6b 100%) border-box;
+  border: 2px solid transparent;
 }
 
 /* Vasemman palstan sisältö */
@@ -16,30 +21,34 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 0;
-  gap: 40px;
-  text-align: left;
+  gap: 24px;
   color: var(--color-text-default);
-  font-family: var(--font-title);
+  padding: 0;
 }
 
 .logo-big {
   max-width: 220px;
+  width: 100%;
+  height: auto;
 }
 
 .welcome-block h1 {
   font-size: var(--fs-h1);
   font-weight: var(--font-weight-bold);
   font-family: var(--font-title);
+  margin: 0;
 }
 
 .welcome-block p {
   color: var(--color-text-dark);
+  margin: 0;
 }
 
 .v-divider {
   width: 1px;
-  background: #404040;
+  background-image: var(--color-gray-v2);
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
   align-self: stretch;
   margin-block: 24px;
   border-radius: 1px;
@@ -50,43 +59,79 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background: transparent;
 }
 
+/* Login-frame asetukset */
 .login-frame {
   width: 100%;
-  max-width: 400px;
+  max-width: 520px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 25px;
+  align-items: stretch;
+  gap: 14px;
+}
+
+.login-frame > app-button {
+  display: block;
+  margin-inline: auto;
+  width: 85%;
+}
+.login-frame > app-button .btn {
+  width: 100%;
+  box-sizing: border-box;
+  justify-content: flex-start;
+  padding-left: 1.25rem;
 }
 
 /* Linebreak */
 .linebreak {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 12px;
   width: 100%;
+  margin-top: 8px;
+  margin-bottom: 8px;
 }
 .linebreak-child {
   flex: 1;
   height: 1px;
-  background: var(--color-gray-v1);
+  background-image: var(--color-gray-v2);
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  border-radius: 1px;
 }
+
 .painike {
   font-size: var(--fs-sm-18);
-  color: #ccc;
+  color: var(--color-text-default);
+  text-align: center;
+}
+
+.already {
+  text-align: center;
+  margin-top: 6px;
+  margin-bottom: 2px;
+  align-self: center;
+  width: 100%;
 }
 
 /* Responsiivisuus */
 @media (max-width: 900px) {
   .container-opaque {
     grid-template-columns: 1fr;
-    gap: 24px;
-    padding: 50px;
+    gap: 28px;
+    padding-block: 48px;
+    padding-inline: 28px;
+  }
+
+  .welcome-block {
+    margin-bottom: 28px;
   }
   .v-divider {
     display: none;
+  }
+
+  .login-frame {
+    gap: 12px;
   }
 }

--- a/frontend/src/app/features/login-page/login-page.component.html
+++ b/frontend/src/app/features/login-page/login-page.component.html
@@ -1,35 +1,27 @@
 <div class="container-opaque">
-
-  <!-- Vasemman puolen sisältö -->
-
   <div class="left-column">
     <img src="assets/svg/logo_big.svg" alt="Synerra logo" class="logo-big" />
-
     <div class="welcome-block">
       <h1>Welcome to Synerra</h1>
-      <p class="text-sm-18">
-        Find teammates, reduce toxicity, enjoy the game.
-      </p>
+      <p class="text-sm-18">Find teammates, reduce toxicity, enjoy the game.</p>
     </div>
   </div>
 
-
-  <!-- Pystysuuntainen jakaja kortin sisällä -->
-
   <div class="v-divider" aria-hidden="true"></div>
-
-
-  <!-- Oikean puolen sisältö -->
 
   <div class="right-column">
     <div class="login-frame">
-      <app-button label="Login with Steam" icon="Steam" variant="default" size="large"></app-button>
+      <app-button label="Login with Steam" icon="Steam" variant="default" size="large" [fullWidth]="true"
+        align="left"></app-button>
 
-      <app-button label="Login with Google" icon="Google" variant="default" size="large"></app-button>
+      <app-button label="Login with Google" icon="Google" variant="default" size="large" [fullWidth]="true"
+        align="left"></app-button>
 
-      <app-button label="Login with Epic Games" icon="EpicGames" variant="default" size="large"></app-button>
+      <app-button label="Login with Epic Games" icon="EpicGames" variant="default" size="large" [fullWidth]="true"
+        align="left"></app-button>
 
-      <app-button label="Login with Email" icon="Mail" variant="default" size="large"></app-button>
+      <app-button label="Login with Email" icon="Mail" variant="default" size="large" [fullWidth]="true"
+        align="left"></app-button>
 
       <div class="linebreak">
         <div class="linebreak-child"></div>
@@ -37,10 +29,9 @@
         <div class="linebreak-child"></div>
       </div>
 
-      <b class="text-sm-bold">Already part of the team?</b>
-      <app-button label="Signup" variant="highlight" size="large"></app-button>
+      <div class="already text-sm-bold">Already part of the team?</div>
+
+      <app-button label="Signup" variant="highlight" size="large" [fullWidth]="true" align="center"></app-button>
     </div>
   </div>
-
-
 </div>

--- a/frontend/src/app/shared/components/button/button.component.css
+++ b/frontend/src/app/shared/components/button/button.component.css
@@ -1,4 +1,7 @@
 /* ===== Button base ===== */
+:host {
+  display: block;
+}
 
 .btn {
   --btn-radius: 8px;
@@ -8,28 +11,32 @@
   overflow: hidden;
   border-radius: var(--btn-radius);
   font-weight: var(--font-weight-medium);
-  padding: 0.75rem 1.5rem;
   cursor: pointer;
+
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.6rem; /* Tässä voi säätää gappia ikonin ja tekstin väliin napissa */
+
   font-family: var(--font-main);
   font-size: var(--fs-sm-18);
   border: 1px solid transparent;
   outline: none;
 
-  /* moderni “elevated” varjo + sulavat siirtymät */
+  padding: 0.75rem 1.5rem;
+  min-height: 48px;
+  box-sizing: border-box;
+
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25),
     0 1px 0 rgba(255, 255, 255, 0.06) inset;
   transition: transform 160ms var(--btn-ease), box-shadow 220ms var(--btn-ease),
     background 200ms ease, filter 200ms ease, border-color 200ms ease;
 
   will-change: transform, box-shadow, filter;
-  transform: translateZ(0); /* GPU */
+  transform: translateZ(0);
 }
 
-/* Yläkiillon kevyt “glass” -overlay */
+/* Kiilto ja sweep */
 .btn::before {
   content: "";
   position: absolute;
@@ -37,13 +44,11 @@
   background: linear-gradient(
     to bottom,
     rgba(255, 255, 255, 0.08),
-    rgba(255, 255, 255, 0) 40%
+    transparent 40%
   );
   pointer-events: none;
   mix-blend-mode: soft-light;
 }
-
-/* Liukuva kiiltoviiva (shine sweep) */
 .btn::after {
   content: "";
   position: absolute;
@@ -53,17 +58,17 @@
   height: 200%;
   background: linear-gradient(
     70deg,
-    rgba(255, 255, 255, 0) 0%,
+    transparent 0%,
     rgba(255, 255, 255, 0.28) 50%,
-    rgba(255, 255, 255, 0) 100%
+    transparent 100%
   );
-  transform: translateX(-100%) rotate(0.001deg);
+  transform: translateX(-100%);
   opacity: 0;
   transition: transform 900ms var(--btn-ease), opacity 200ms ease;
   pointer-events: none;
 }
 
-/* Hover: hieman isompi, pehmeämpi varjo, shine liukuu yli */
+/* Hover / active / focus */
 .btn:hover {
   transform: translateY(-1px) scale(1.01);
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35),
@@ -74,9 +79,8 @@
   opacity: 0.9;
 }
 
-/* Painaessa “uppoaa” sisäänpäin (neumorphic-inset) */
 .btn:active {
-  transform: translateY(0) scale(0.985);
+  transform: scale(0.985);
   box-shadow: inset 0 6px 14px rgba(0, 0, 0, 0.45),
     inset 0 -1px 0 rgba(255, 255, 255, 0.08), 0 3px 8px rgba(0, 0, 0, 0.25);
   filter: brightness(0.98);
@@ -85,82 +89,96 @@
   opacity: 0;
 }
 
-/* Näppäimistöfokus: kontrastinen rengas (WCAG) */
 .btn:focus-visible {
   box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.14),
     0 0 0 4px var(--accent-color, #ff6a2b), 0 10px 24px rgba(0, 0, 0, 0.35);
 }
 
-/* Disabled */
-.btn:disabled,
-.btn.btn-disabled {
+.btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   transform: none;
-  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  box-shadow: none;
 }
 
 /* ===== Variants ===== */
-
 .btn-default {
-  color: var(--color-text-color, #e9e9e9);
+  color: var(--color-text-default);
   background: linear-gradient(180deg, #2b2b2b 0%, #1f1f1f 100%);
   border-color: var(--color-border, #3a3a3a);
 }
 .btn-default:hover {
   background: linear-gradient(180deg, #323232 0%, #222 100%);
-  border-color: #4a4a4a;
-}
-.btn-default:active {
-  background: linear-gradient(180deg, #242424 0%, #1b1b1b 100%);
 }
 
-/* Highlight / CTA — käytä tokeniasi, fallbackina oranssi gradientti */
 .btn-highlight {
-  color: var(--color-text-color, #fff);
+  color: var(--color-text-default);
   background: var(
     --color-orange-gradient,
     linear-gradient(180deg, #ff7a3e 0%, #e34b0e 100%)
   );
   border-color: rgba(255, 122, 62, 0.4);
 }
-.btn-highlight:hover {
-  /* hieman kirkkaampi ja lämpimämpi */
-  background: linear-gradient(180deg, #ff8a54 0%, #e05212 100%);
-  border-color: rgba(255, 138, 84, 0.6);
-}
-.btn-highlight:active {
-  background: linear-gradient(180deg, #e56f3a 0%, #c3430d 100%);
-}
 
 /* ===== Sizes ===== */
-
 .btn-small {
   font-size: 0.875rem;
-  padding: 0.5rem 0.9rem;
+  min-height: 40px;
+  padding: 0.5rem 1rem;
 }
 .btn-medium {
   font-size: 1rem;
-  padding: 0.6rem 1.2rem;
 }
 .btn-large {
   font-size: 1.125rem;
-  padding: 1rem 1.5rem;
+  min-height: 56px;
+  padding: 1rem 1.25rem;
 }
 
 /* Täysleveä */
 .btn-full {
   width: 100%;
+  box-sizing: border-box;
 }
 
-/* Ikoni koko 24px tokenin mukaan */
+/* Ikoni */
 .btn-icon {
   width: 24px;
   height: 24px;
-  flex: 0 0 24px;
+  object-fit: contain;
+  flex-shrink: 0;
+  margin-right: 0.75rem;
 }
 
-/* Motion: kun käyttäjä vähentää animaatiota, hidastetaan ja poistetaan sweep */
+.btn-left {
+  justify-content: flex-start;
+  padding-left: 1.25rem;
+}
+.btn-left .btn-label {
+  text-align: left;
+}
+
+.app-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  border: none;
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.app-button.right {
+  flex-direction: row-reverse;
+}
+
+.btn-label {
+  display: inline-block;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* Kiiltoefektin liikkeen nopeuden säätö */
 @media (prefers-reduced-motion: reduce) {
   .btn,
   .btn::after {

--- a/frontend/src/app/shared/components/button/button.component.html
+++ b/frontend/src/app/shared/components/button/button.component.html
@@ -12,22 +12,31 @@ Active
 Highlight
 <app-button label="Painike" variant="highlight"></app-button>
 
-Ikoni
-<app-button label="Painike" variant="default" icon="steam"></app-button>
+Ikoni vasemmalla (default)
+<app-button label="Login with Google" icon="Google"></app-button>
+
+Ikoni oikealla
+<app-button label="Next Step" icon="ArrowRight" iconPosition="right"></app-button>
 
 Suuri koko
 <app-button label="Painike" variant="highlight" size="large"></app-button>
 
 -->
 
-
-<button class="btn 
-    btn-{{ variant }} 
-    {{ state ? 'btn-' + state : '' }} 
-    {{ size ? 'btn-' + size : '' }}
-    {{ fullWidth ? 'btn-full' : '' }}">
-  <ng-container *ngIf="icon">
+<button class="btn" [class.btn-default]="variant === 'default'" [class.btn-highlight]="variant === 'highlight'"
+  [class.btn-small]="size === 'small'" [class.btn-medium]="size === 'medium'" [class.btn-large]="size === 'large'"
+  [class.btn-full]="fullWidth" [class.btn-left]="align === 'left'" [class.btn-active]="state === 'active'"
+  [class.btn-icon-right]="iconPosition === 'right'" [attr.aria-disabled]="state === 'disabled' ? true : null"
+  [disabled]="state === 'disabled'">
+  <!-- Ikoni vasemmalla -->
+  <ng-container *ngIf="icon && iconPosition === 'left'">
     <img [src]="'assets/svg/' + icon + '.svg'" alt="{{ icon }} icon" class="btn-icon" />
   </ng-container>
-  {{ label }}
+
+  <span class="btn-label">{{ label }}</span>
+
+  <!-- Ikoni oikealla -->
+  <ng-container *ngIf="icon && iconPosition === 'right'">
+    <img [src]="'assets/svg/' + icon + '.svg'" alt="{{ icon }} icon" class="btn-icon" />
+  </ng-container>
 </button>

--- a/frontend/src/app/shared/components/button/button.component.ts
+++ b/frontend/src/app/shared/components/button/button.component.ts
@@ -4,6 +4,8 @@ import { CommonModule } from '@angular/common';
 type ButtonVariant = 'default' | 'highlight';
 type ButtonState = 'active' | 'disabled';
 type ButtonSize = 'small' | 'medium' | 'large';
+type ButtonAlign = 'left' | 'center';
+type IconPosition = 'left' | 'right';
 
 @Component({
   selector: 'app-button',
@@ -13,9 +15,30 @@ type ButtonSize = 'small' | 'medium' | 'large';
 })
 export class ButtonComponent {
   @Input() label: string = '';
-  @Input() icon?: string; // esim. steam, google, epic, mail
+  @Input() icon?: string;
   @Input() variant: ButtonVariant = 'default';
   @Input() state?: ButtonState;
-  @Input() size?: ButtonSize;
-  @Input() fullWidth: boolean = false;
+  @Input() size: ButtonSize = 'medium';
+  @Input() iconPosition: IconPosition = 'left';
+
+  private _fullWidth = false;
+
+  @Input('fullWidth')
+  set fullWidth(val: any) {
+    this._fullWidth = this.coerceBoolean(val);
+  }
+  get fullWidth(): boolean {
+    return this._fullWidth;
+  }
+
+  @Input('full-width')
+  set fullWidthKebab(val: any) {
+    this.fullWidth = val;
+  }
+
+  @Input() align: ButtonAlign = 'center';
+
+  private coerceBoolean(v: any): boolean {
+    return v === '' || v === true || v === 'true' || v === 'on';
+  }
 }


### PR DESCRIPTION
Title / Otsikko:
Parannettu login-page ja nappien ikonien tuki (left/right)

Description / Kuvaus:
Tässä PR:ssä on tehty seuraavat muutokset:
	•	Lisätty iconPosition-ominaisuus app-button-komponenttiin, jolloin ikoni voidaan näyttää joko vasemmalla tai oikealla. Käyttöohjeet löytyy button.component.html tiedostosta kommentoituna.
	•	Parannettu nappien kokoa ja marginaaleja, jotta ne ovat yhtenäisiä ja responsiivisia.
	•	Muokattu login-page layoutia:
	•	Containerin border ja linebreakit käyttävät nyt gradienttia (--color-gray-v2).
	•	“Already part of the team?” -teksti keskitetty.
	•	Responsiivisuudessa lisätty enemmän tilaa ylös/alas ja nappien ja welcome-tekstin väliin.
	•	Pieniä CSS-siivouksia ja muuttujien käyttö yhtenäistetty.

Testing / Testaus:
	•	Varmistettu, että kaikki login-sivun napit näkyvät oikein eri näytön kooissa.
	•	Hover ja active -animaatiot toimivat normaalisti.
	•	Ikoni näkyy oikeassa tai vasemmassa reunassa iconPosition-asetuksen mukaan.